### PR TITLE
feat: more readable code blocks by updating highlighting styles

### DIFF
--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -65,7 +65,7 @@ This format allows users to include data directly in the Gosling's JSON specific
       "genomicFields": [
           "chromStart",
           "chromEnd"
-      ]
+      ],
       "values": [
         {
           "Chromosome": "chr1",
@@ -80,8 +80,7 @@ This format allows users to include data directly in the Gosling's JSON specific
           "chromEnd": 5300000,
           "Name": "p36.32",
           "Stain": "gpos25"
-        }
-        .....
+        }, ...
         ]
     },
     ... // other configurations of this track

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -30,6 +30,58 @@
   --ifm-h2-font-size: 2rem;
 }
 
+
+/* Code Blocks */
+code, .prism-code {
+  font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  background-color: #F6F8FA;
+  border: none;
+}
+
+.comment, 
+.doctype, 
+.doctype-type {
+  font-style: normal !important;
+}
+
+.comment {
+  color: #6F7781 !important; /* GitHub color */
+}
+
+.doctype,
+.doctype-type,
+.number {
+  color: #0450AE !important; /* GitHub color */
+}
+
+.tag {
+  color: #146229 !important; /* GiHub color */
+}
+
+.maybe-class-name {
+  color: #146229 !important; /* GitHub color  */
+}
+
+.attr-name {
+  color: #0450AE !important; /* darker than original */
+}
+
+.attr-value {
+  color: #0A2F69 !important; /* GiHub color */
+}
+
+.dom, .variable {
+  color: black !important; /* GitHub color */
+}
+
+.method, .function, .property-access {
+  color: #8250DF !important; /* GitHub color */
+}
+
+.plain, .constant, .string, .operator {
+ color: #0A2F69 !important; /* GitHub color */
+}
+
 html[data-theme='dark'] {
   --ifm-color-primary: #faa433;
   /* any other colors you wish to overwrite */


### PR DESCRIPTION
Updated the styles of code blocks so that codes are more readable. Especially, I wanted to prevent using vivid colors (e.g., cyan) that made it hard to read. I mainly referred to the actual GitHub code block styles. Other than that, I made small styling changes and fixed typos.

## Previous

<img width="913" alt="Screen Shot 2021-10-22 at 1 04 41 PM" src="https://user-images.githubusercontent.com/9922882/138398965-f8c8555b-8e77-4af9-bf42-e5b5ed5cfc84.png">

## Current

<img width="907" alt="Screen Shot 2021-10-22 at 2 34 43 PM" src="https://user-images.githubusercontent.com/9922882/138398934-5f32d40e-20c1-4bd5-a443-4220a59d2e15.png">