### PR TITLE
Fix beddb typo

### DIFF
--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -25,7 +25,7 @@ For the flexible data exploration, Gosling supports two different kinds of datas
 including [CSV](#csv-no-higlass-server), [JSON](#json-no-higlass-server), [BigWig](#bigwig-no-higlass-server), [BAM](#bam-no-higlass-server). 
 
 2. **Pre-aggregated Datasets** (HiGlass Server): These datasets are preprocessed for the scalable data exploration and require a HiGlass server to access them in Gosling,
-including [Vector](#vector-require-higlass-server), [Multivec](#multivec-require-higlass-server), and [BEDDE](#beddb-require-higlass-server).
+including [Vector](#vector-require-higlass-server), [Multivec](#multivec-require-higlass-server), and [BEDDB](#beddb-require-higlass-server).
 To learn more about preprocessing your data and setting up the server, please visit the [HiGlass website](https://docs.higlass.io/).
 
 


### PR DESCRIPTION
At first I thought `BEDDE` might be a new file format 😄 