### PR TITLE
docs: add bed file documentation

### DIFF
--- a/docs/assets/gosling.schema.json
+++ b/docs/assets/gosling.schema.json
@@ -13,17 +13,43 @@
       "type": "string"
     },
     "Assembly": {
-      "enum": [
-        "hg38",
-        "hg19",
-        "hg18",
-        "hg17",
-        "hg16",
-        "mm10",
-        "mm9",
-        "unknown"
-      ],
-      "type": "string"
+      "anyOf": [
+        {
+          "const": "hg38",
+          "type": "string"
+        },
+        {
+          "const": "hg19",
+          "type": "string"
+        },
+        {
+          "const": "hg18",
+          "type": "string"
+        },
+        {
+          "const": "hg17",
+          "type": "string"
+        },
+        {
+          "const": "hg16",
+          "type": "string"
+        },
+        {
+          "const": "mm10",
+          "type": "string"
+        },
+        {
+          "const": "mm9",
+          "type": "string"
+        },
+        {
+          "const": "unknown",
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/ChromSizes"
+        }
+      ]
     },
     "AxisPosition": {
       "enum": [
@@ -35,18 +61,28 @@
       ],
       "type": "string"
     },
-    "BAMData": {
+    "BamData": {
       "additionalProperties": false,
       "description": "Binary Alignment Map (BAM) is the comprehensive raw data of genome sequencing; it consists of the lossless, compressed binary representation of the Sequence Alignment Map-files.",
       "properties": {
+        "extractJunction": {
+          "description": "Determine whether to extract exon-to-exon junctions. __Default__: `false`",
+          "type": "boolean"
+        },
         "indexUrl": {
           "description": "URL link to the index file of the BAM file",
           "type": "string"
         },
+        "junctionMinCoverage": {
+          "description": "Determine the threshold of coverage when extracting exon-to-exon junctions. __Default__: `1`",
+          "type": "number"
+        },
         "loadMates": {
+          "description": "Load mates that are located in the same chromosome. __Default__: `false`",
           "type": "boolean"
         },
         "maxInsertSize": {
+          "description": "Determines the threshold of insert sizes for determining the structural variants. __Default__: `5000`",
           "type": "number"
         },
         "type": {
@@ -65,7 +101,42 @@
       ],
       "type": "object"
     },
-    "BEDDBData": {
+    "BedData": {
+      "additionalProperties": false,
+      "description": "BED file format",
+      "properties": {
+        "customFields": {
+          "description": "An array of strings, where each string is the name of a non-standard field in the BED file. If there are `n` custom fields, we assume that the last `n` columns of the BED file correspond to the custom fields.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "indexUrl": {
+          "description": "Specify the URL address of the data file index.",
+          "type": "string"
+        },
+        "sampleLength": {
+          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
+          "type": "number"
+        },
+        "type": {
+          "const": "bed",
+          "type": "string"
+        },
+        "url": {
+          "description": "Specify the URL address of the data file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url",
+        "indexUrl"
+      ],
+      "type": "object"
+    },
+    "BeddbData": {
       "additionalProperties": false,
       "description": "Regular BED or similar files can be pre-aggregated for the scalable data exploration. Find our more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bed-files).",
       "properties": {
@@ -173,23 +244,27 @@
       ],
       "type": "object"
     },
-    "BIGWIGData": {
+    "BigWigData": {
       "additionalProperties": false,
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -201,92 +276,7 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "url",
-        "column",
-        "value"
-      ],
-      "type": "object"
-    },
-    "CSVData": {
-      "additionalProperties": false,
-      "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
-      "properties": {
-        "chromosomeField": {
-          "description": "Specify the name of chromosome data fields.",
-          "type": "string"
-        },
-        "chromosomePrefix": {
-          "description": "experimental",
-          "type": "string"
-        },
-        "genomicFields": {
-          "description": "Specify the name of genomic data fields.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "genomicFieldsToConvert": {
-          "description": "experimental",
-          "items": {
-            "additionalProperties": false,
-            "properties": {
-              "chromosomeField": {
-                "type": "string"
-              },
-              "genomicFields": {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "chromosomeField",
-              "genomicFields"
-            ],
-            "type": "object"
-          },
-          "type": "array"
-        },
-        "headerNames": {
-          "description": "Specify the names of data fields if a CSV file is headerless.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "longToWideId": {
-          "description": "experimental",
-          "type": "string"
-        },
-        "quantitativeFields": {
-          "description": "Specify the name of quantitative data fields.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "sampleLength": {
-          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
-          "type": "number"
-        },
-        "separator": {
-          "description": "Specify file separator, __Default:__ ','",
-          "type": "string"
-        },
-        "type": {
-          "const": "csv",
-          "type": "string"
-        },
-        "url": {
-          "description": "Specify the URL address of the data file.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },
@@ -295,6 +285,13 @@
         "url"
       ],
       "type": "object"
+    },
+    "BinAggregate": {
+      "enum": [
+        "mean",
+        "sum"
+      ],
+      "type": "string"
     },
     "Channel": {
       "anyOf": [
@@ -353,60 +350,22 @@
       ],
       "type": "object"
     },
-    "Chromosome": {
-      "enum": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12",
-        "13",
-        "14",
-        "15",
-        "16",
-        "17",
-        "18",
-        "19",
-        "20",
-        "21",
-        "22",
-        "X",
-        "Y",
-        "M",
-        "chr1",
-        "chr2",
-        "chr3",
-        "chr4",
-        "chr5",
-        "chr6",
-        "chr7",
-        "chr8",
-        "chr9",
-        "chr10",
-        "chr11",
-        "chr12",
-        "chr13",
-        "chr14",
-        "chr15",
-        "chr16",
-        "chr17",
-        "chr18",
-        "chr19",
-        "chr20",
-        "chr21",
-        "chr22",
-        "chrX",
-        "chrY",
-        "chrM"
-      ],
-      "type": "string"
+    "ChromSizes": {
+      "description": "Custom chromosome sizes, e.g., [[\"foo\", 1000], [\"bar\", 300], [\"baz\", 240]]",
+      "items": {
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array"
+      },
+      "type": "array"
     },
     "Color": {
       "additionalProperties": false,
@@ -427,6 +386,26 @@
           "$ref": "#/definitions/Range",
           "description": "Determine the colors that should be bound to data value. Default properties are determined considering the field type."
         },
+        "scale": {
+          "enum": [
+            "linear",
+            "log"
+          ],
+          "type": "string"
+        },
+        "scaleOffset": {
+          "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "title": {
+          "description": "Title of the legend. __Default__: `undefined`",
+          "type": "string"
+        },
         "type": {
           "description": "Specify the data type",
           "enum": [
@@ -436,33 +415,6 @@
           "type": "string"
         }
       },
-      "type": "object"
-    },
-    "CombineMatesTransform": {
-      "additionalProperties": false,
-      "description": "By looking up ids, combine mates (a pair of reads) into a single row, performing long-to-wide operation. Result data have `{field}` and `{field}_2` names.",
-      "properties": {
-        "idField": {
-          "type": "string"
-        },
-        "isLongField": {
-          "type": "string"
-        },
-        "maintainDuplicates": {
-          "type": "boolean"
-        },
-        "maxInsertSize": {
-          "type": "number"
-        },
-        "type": {
-          "const": "combineMates",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "idField"
-      ],
       "type": "object"
     },
     "CoverageTransform": {
@@ -494,22 +446,101 @@
       ],
       "type": "object"
     },
+    "CsvData": {
+      "additionalProperties": false,
+      "description": "Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can be loaded using \"csv\" data specification.",
+      "properties": {
+        "chromosomeField": {
+          "description": "Specify the name of chromosome data fields.",
+          "type": "string"
+        },
+        "chromosomePrefix": {
+          "description": "Specify the chromosome prefix if chromosomes are denoted using a prefix besides \"chr\" or a number",
+          "type": "string"
+        },
+        "genomicFields": {
+          "description": "Specify the name of genomic data fields.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "genomicFieldsToConvert": {
+          "description": "experimental",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "chromosomeField": {
+                "type": "string"
+              },
+              "genomicFields": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "chromosomeField",
+              "genomicFields"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "headerNames": {
+          "description": "Specify the names of data fields if a CSV file does not contain a header.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "longToWideId": {
+          "description": "experimental",
+          "type": "string"
+        },
+        "sampleLength": {
+          "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
+          "type": "number"
+        },
+        "separator": {
+          "description": "Specify file separator, __Default:__ ','",
+          "type": "string"
+        },
+        "type": {
+          "const": "csv",
+          "type": "string"
+        },
+        "url": {
+          "description": "Specify the URL address of the data file.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
     "DataDeep": {
       "anyOf": [
         {
-          "$ref": "#/definitions/JSONData"
+          "$ref": "#/definitions/JsonData"
         },
         {
-          "$ref": "#/definitions/CSVData"
+          "$ref": "#/definitions/CsvData"
         },
         {
-          "$ref": "#/definitions/BIGWIGData"
+          "$ref": "#/definitions/BedData"
+        },
+        {
+          "$ref": "#/definitions/BigWigData"
         },
         {
           "$ref": "#/definitions/MultivecData"
         },
         {
-          "$ref": "#/definitions/BEDDBData"
+          "$ref": "#/definitions/BeddbData"
         },
         {
           "$ref": "#/definitions/VectorData"
@@ -518,7 +549,10 @@
           "$ref": "#/definitions/MatrixData"
         },
         {
-          "$ref": "#/definitions/BAMData"
+          "$ref": "#/definitions/BamData"
+        },
+        {
+          "$ref": "#/definitions/VcfData"
         }
       ]
     },
@@ -526,6 +560,13 @@
       "additionalProperties": false,
       "description": "Partial specification of `BasicSingleTrack` to use default visual encoding predefined by data type.",
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "_invalidTrack": {
           "description": "internal",
           "type": "boolean"
@@ -585,7 +626,7 @@
           "type": "object"
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -598,7 +639,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
@@ -626,11 +667,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -641,9 +697,7 @@
         }
       },
       "required": [
-        "data",
-        "height",
-        "width"
+        "data"
       ],
       "type": "object"
     },
@@ -671,13 +725,13 @@
           "$ref": "#/definitions/GenomicLengthTransform"
         },
         {
+          "$ref": "#/definitions/SvTypeTransform"
+        },
+        {
           "$ref": "#/definitions/CoverageTransform"
         },
         {
-          "$ref": "#/definitions/CombineMatesTransform"
-        },
-        {
-          "$ref": "#/definitions/JSONParseTransform"
+          "$ref": "#/definitions/JsonParseTransform"
         }
       ]
     },
@@ -730,7 +784,7 @@
         },
         "method": {
           "$ref": "#/definitions/DisplacementType",
-          "description": "A string that specifies the type of diseplancement."
+          "description": "A string that specifies the type of displacement."
         },
         "newField": {
           "type": "string"
@@ -774,7 +828,7 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome"
+          "type": "string"
         }
       },
       "required": [
@@ -786,18 +840,13 @@
       "additionalProperties": false,
       "properties": {
         "chromosome": {
-          "$ref": "#/definitions/Chromosome",
-          "description": "If specified, only showing a certain interval in a chromosome."
+          "description": "If specified, only showing a certain interval in a chromosome.",
+          "type": "string"
         },
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -809,47 +858,14 @@
       ],
       "type": "object"
     },
-    "DomainGene": {
-      "additionalProperties": false,
-      "properties": {
-        "gene": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "items": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "string"
-                }
-              ],
-              "maxItems": 2,
-              "minItems": 2,
-              "type": "array"
-            }
-          ]
-        }
-      },
-      "required": [
-        "gene"
-      ],
-      "type": "object"
-    },
     "DomainInterval": {
       "additionalProperties": false,
       "properties": {
         "interval": {
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "description": "Show a certain interval within entire chromosome",
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -858,6 +874,40 @@
       "required": [
         "interval"
       ],
+      "type": "object"
+    },
+    "EventStyle": {
+      "additionalProperties": false,
+      "description": "The styles defined here will be applied to the target marks of mouse events, such as a point mark after the user clicks on it.",
+      "properties": {
+        "arrange": {
+          "description": "Show event effects behind or in front of marks.",
+          "enum": [
+            "behind",
+            "front"
+          ],
+          "type": "string"
+        },
+        "color": {
+          "description": "color of the marks when mouse events are triggered",
+          "type": "string"
+        },
+        "opacity": {
+          "description": "opacity of the marks when mouse events are triggered",
+          "type": "number"
+        },
+        "stroke": {
+          "description": "stroke color of the marks when mouse events are triggered",
+          "type": "string"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "stroke width of the marks when mouse events are triggered",
+          "type": "number"
+        }
+      },
       "type": "object"
     },
     "ExonSplitTransform": {
@@ -946,81 +996,6 @@
         }
       ]
     },
-    "FlatTracks": {
-      "additionalProperties": false,
-      "properties": {
-        "assembly": {
-          "$ref": "#/definitions/Assembly",
-          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-        },
-        "centerRadius": {
-          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout",
-          "description": "Specify the layout type of all tracks."
-        },
-        "linkingId": {
-          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
-          "type": "string"
-        },
-        "orientation": {
-          "$ref": "#/definitions/Orientation",
-          "description": "Specify the orientation."
-        },
-        "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
-          "type": "number"
-        },
-        "static": {
-          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
-          "type": "boolean"
-        },
-        "style": {
-          "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
-        },
-        "tracks": {
-          "items": {
-            "$ref": "#/definitions/Track"
-          },
-          "type": "array"
-        },
-        "xAxis": {
-          "$ref": "#/definitions/AxisPosition",
-          "description": "not supported"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xOffset": {
-          "description": "Specify the x offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "yOffset": {
-          "description": "Specify the y offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "zoomLimits": {
-          "$ref": "#/definitions/ZoomLimits"
-        }
-      },
-      "required": [
-        "tracks"
-      ],
-      "type": "object"
-    },
     "GenomicDomain": {
       "anyOf": [
         {
@@ -1031,9 +1006,6 @@
         },
         {
           "$ref": "#/definitions/DomainChr"
-        },
-        {
-          "$ref": "#/definitions/DomainGene"
         }
       ]
     },
@@ -1066,10 +1038,2308 @@
     "GoslingSpec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/RootSpecWithSingleView"
+          "additionalProperties": false,
+          "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
+            "_invalidTrack": {
+              "description": "internal",
+              "type": "boolean"
+            },
+            "_renderingId": {
+              "description": "internal",
+              "type": "string"
+            },
+            "alignment": {
+              "const": "overlay",
+              "type": "string"
+            },
+            "assembly": {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "baselineY": {
+              "type": "number"
+            },
+            "centerRadius": {
+              "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+              "type": "number"
+            },
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Color"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "data": {
+              "$ref": "#/definitions/DataDeep"
+            },
+            "dataTransform": {
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "displacement": {
+              "$ref": "#/definitions/Displacement"
+            },
+            "endAngle": {
+              "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "flipY": {
+              "type": "boolean"
+            },
+            "height": {
+              "description": "Specify the track height in pixels.",
+              "type": "number"
+            },
+            "id": {
+              "type": "string"
+            },
+            "innerRadius": {
+              "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "layout": {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            "linkingId": {
+              "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+              "type": "string"
+            },
+            "mark": {
+              "$ref": "#/definitions/Mark"
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Opacity"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "orientation": {
+              "$ref": "#/definitions/Orientation",
+              "description": "Specify the orientation."
+            },
+            "outerRadius": {
+              "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+              "type": "number"
+            },
+            "overlayOnPreviousTrack": {
+              "type": "boolean"
+            },
+            "overrideTemplate": {
+              "type": "boolean"
+            },
+            "prerelease": {
+              "additionalProperties": false,
+              "description": "internal",
+              "type": "object"
+            },
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
+            },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "row": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Row"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Size"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "spacing": {
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+              "type": "number"
+            },
+            "startAngle": {
+              "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "static": {
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            },
+            "stretch": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Stroke"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "strokeWidth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StrokeWidth"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "style": {
+              "$ref": "#/definitions/Style",
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+            },
+            "subtitle": {
+              "type": "string"
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Text"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "title": {
+              "description": "If defined, will show the textual label on the left-top corner of a track.",
+              "type": "string"
+            },
+            "tooltip": {
+              "items": {
+                "$ref": "#/definitions/Tooltip"
+              },
+              "type": "array"
+            },
+            "tracks": {
+              "items": {
+                "$ref": "#/definitions/PartialTrack"
+              },
+              "type": "array"
+            },
+            "visibility": {
+              "items": {
+                "$ref": "#/definitions/VisibilityCondition"
+              },
+              "type": "array"
+            },
+            "width": {
+              "description": "Specify the track width in pixels.",
+              "type": "number"
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "x1": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "x1e": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "xAxis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "not supported"
+            },
+            "xDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic x-axis"
+            },
+            "xOffset": {
+              "description": "Specify the x offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "xe": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y1": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y1e": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
+            "yOffset": {
+              "description": "Specify the y offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "ye": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "zoomLimits": {
+              "$ref": "#/definitions/ZoomLimits"
+            }
+          },
+          "required": [
+            "alignment",
+            "tracks"
+          ],
+          "type": "object"
         },
         {
-          "$ref": "#/definitions/RootSpecWithMultipleViews"
+          "additionalProperties": false,
+          "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
+            "_invalidTrack": {
+              "description": "internal",
+              "type": "boolean"
+            },
+            "_renderingId": {
+              "description": "internal",
+              "type": "string"
+            },
+            "alignment": {
+              "const": "stack",
+              "type": "string"
+            },
+            "assembly": {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "baselineY": {
+              "type": "number"
+            },
+            "centerRadius": {
+              "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+              "type": "number"
+            },
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Color"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "data": {
+              "$ref": "#/definitions/DataDeep"
+            },
+            "dataTransform": {
+              "items": {
+                "$ref": "#/definitions/DataTransform"
+              },
+              "type": "array"
+            },
+            "description": {
+              "type": "string"
+            },
+            "displacement": {
+              "$ref": "#/definitions/Displacement"
+            },
+            "endAngle": {
+              "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "flipY": {
+              "type": "boolean"
+            },
+            "height": {
+              "description": "Specify the track height in pixels.",
+              "type": "number"
+            },
+            "id": {
+              "type": "string"
+            },
+            "innerRadius": {
+              "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "layout": {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            "linkingId": {
+              "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+              "type": "string"
+            },
+            "mark": {
+              "$ref": "#/definitions/Mark"
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Opacity"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "orientation": {
+              "$ref": "#/definitions/Orientation",
+              "description": "Specify the orientation."
+            },
+            "outerRadius": {
+              "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+              "type": "number"
+            },
+            "overlayOnPreviousTrack": {
+              "type": "boolean"
+            },
+            "overrideTemplate": {
+              "type": "boolean"
+            },
+            "prerelease": {
+              "additionalProperties": false,
+              "description": "internal",
+              "type": "object"
+            },
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
+            },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "row": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Row"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Size"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "spacing": {
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+              "type": "number"
+            },
+            "startAngle": {
+              "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+              "type": "number"
+            },
+            "static": {
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            },
+            "stretch": {
+              "type": "boolean"
+            },
+            "stroke": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Stroke"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "strokeWidth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StrokeWidth"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "style": {
+              "$ref": "#/definitions/Style",
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+            },
+            "subtitle": {
+              "type": "string"
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Text"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "title": {
+              "description": "If defined, will show the textual label on the left-top corner of a track.",
+              "type": "string"
+            },
+            "tooltip": {
+              "items": {
+                "$ref": "#/definitions/Tooltip"
+              },
+              "type": "array"
+            },
+            "tracks": {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PartialTrack"
+                  },
+                  {
+                    "$ref": "#/definitions/OverlaidTracks"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "visibility": {
+              "items": {
+                "$ref": "#/definitions/VisibilityCondition"
+              },
+              "type": "array"
+            },
+            "width": {
+              "description": "Specify the track width in pixels.",
+              "type": "number"
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "x1": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "x1e": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "xAxis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "not supported"
+            },
+            "xDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic x-axis"
+            },
+            "xOffset": {
+              "description": "Specify the x offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "xe": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/X"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y1": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "y1e": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
+            "yOffset": {
+              "description": "Specify the y offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "ye": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Y"
+                },
+                {
+                  "$ref": "#/definitions/ChannelValue"
+                }
+              ]
+            },
+            "zoomLimits": {
+              "$ref": "#/definitions/ZoomLimits"
+            }
+          },
+          "required": [
+            "tracks"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
+            "assembly": {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "centerRadius": {
+              "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "layout": {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            "linkingId": {
+              "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+              "type": "string"
+            },
+            "orientation": {
+              "$ref": "#/definitions/Orientation",
+              "description": "Specify the orientation."
+            },
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
+            },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "spacing": {
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+              "type": "number"
+            },
+            "static": {
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            },
+            "style": {
+              "$ref": "#/definitions/Style",
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+            },
+            "subtitle": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "tracks": {
+              "items": {
+                "$ref": "#/definitions/Track"
+              },
+              "type": "array"
+            },
+            "xAxis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "not supported"
+            },
+            "xDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic x-axis"
+            },
+            "xOffset": {
+              "description": "Specify the x offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
+            "yOffset": {
+              "description": "Specify the y offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "zoomLimits": {
+              "$ref": "#/definitions/ZoomLimits"
+            }
+          },
+          "required": [
+            "tracks"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
+            "arrangement": {
+              "description": "Specify how multiple views are arranged.",
+              "enum": [
+                "parallel",
+                "serial",
+                "horizontal",
+                "vertical"
+              ],
+              "type": "string"
+            },
+            "assembly": {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "centerRadius": {
+              "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+              "type": "number"
+            },
+            "description": {
+              "type": "string"
+            },
+            "layout": {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            "linkingId": {
+              "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+              "type": "string"
+            },
+            "orientation": {
+              "$ref": "#/definitions/Orientation",
+              "description": "Specify the orientation."
+            },
+            "responsiveSize": {
+              "$ref": "#/definitions/ResponsiveSize",
+              "description": "Determine whether to make the size of `GoslingComponent` bound to its parent element. __Default__: `false`"
+            },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "arrangement": {
+                        "description": "Specify how multiple views are arranged.",
+                        "enum": [
+                          "parallel",
+                          "serial",
+                          "horizontal",
+                          "vertical"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "views": {
+                        "description": "An array of view specifications",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "$ref": "#/definitions/SingleView"
+                            },
+                            {
+                              "$ref": "#/definitions/MultipleViews"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "spacing": {
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+              "type": "number"
+            },
+            "static": {
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            },
+            "style": {
+              "$ref": "#/definitions/Style",
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+            },
+            "subtitle": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "views": {
+              "description": "An array of view specifications",
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/SingleView"
+                  },
+                  {
+                    "$ref": "#/definitions/MultipleViews"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            "xAxis": {
+              "$ref": "#/definitions/AxisPosition",
+              "description": "not supported"
+            },
+            "xDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic x-axis"
+            },
+            "xOffset": {
+              "description": "Specify the x offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
+            "yOffset": {
+              "description": "Specify the y offset of views in the unit of pixels",
+              "type": "number"
+            },
+            "zoomLimits": {
+              "$ref": "#/definitions/ZoomLimits"
+            }
+          },
+          "required": [
+            "views"
+          ],
+          "type": "object"
         }
       ]
     },
@@ -1100,7 +3370,7 @@
       ],
       "type": "object"
     },
-    "JSONData": {
+    "JsonData": {
       "additionalProperties": false,
       "description": "The JSON data format allows users to include data directly in the Gosling's JSON specification.",
       "properties": {
@@ -1138,13 +3408,6 @@
           },
           "type": "array"
         },
-        "quantitativeFields": {
-          "description": "Specify the name of quantitative data fields.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "sampleLength": {
           "description": "Specify the number of rows loaded from the URL.\n\n__Default:__ `1000`",
           "type": "number"
@@ -1168,7 +3431,7 @@
       ],
       "type": "object"
     },
-    "JSONParseTransform": {
+    "JsonParseTransform": {
       "additionalProperties": false,
       "description": "Parse JSON Object Array and append vertically",
       "properties": {
@@ -1284,11 +3547,28 @@
     "MatrixData": {
       "additionalProperties": false,
       "properties": {
+        "binSize": {
+          "description": "Determine the number of nearby cells to aggregate. __Default__: `1`",
+          "type": "number"
+        },
+        "column": {
+          "description": "The name of the first genomic field. __Default__: `x`",
+          "type": "string"
+        },
+        "row": {
+          "description": "The name of the first genomic field. __Default__: `y`",
+          "type": "string"
+        },
         "type": {
           "const": "matrix",
           "type": "string"
         },
         "url": {
+          "description": "URL link to the matrix data file",
+          "type": "string"
+        },
+        "value": {
+          "description": "The name of the value field. __Default__: `value`",
           "type": "string"
         }
       },
@@ -1298,9 +3578,43 @@
       ],
       "type": "object"
     },
+    "MouseEventsDeep": {
+      "additionalProperties": false,
+      "description": "Options for determining mouse events in detail, e.g., turning on specific events only",
+      "properties": {
+        "click": {
+          "description": "Whether to enable click events.",
+          "type": "boolean"
+        },
+        "enableMouseOverOnMultipleMarks": {
+          "description": "Determine whether all marks underneath the mouse point should be affected by mouse over. __Default__: `false`",
+          "type": "boolean"
+        },
+        "groupMarksByField": {
+          "description": "Group marks using keys in a data field. This affects how a set of marks are highlighted/selected by interaction. __Default__: `undefined`",
+          "type": "string"
+        },
+        "mouseOver": {
+          "description": "Whether to enable mouseover events.",
+          "type": "boolean"
+        },
+        "rangeSelect": {
+          "description": "Whether to send range selection events.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "MultipleViews": {
       "additionalProperties": false,
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "arrangement": {
           "description": "Specify how multiple views are arranged.",
           "enum": [
@@ -1332,7 +3646,7 @@
           "description": "Specify the orientation."
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "static": {
@@ -1341,7 +3655,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "views": {
           "description": "An array of view specifications",
@@ -1372,11 +3686,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -1395,6 +3724,10 @@
       "additionalProperties": false,
       "description": "Two-dimensional quantitative values, one axis for genomic coordinate and the other for different samples, can be converted into HiGlass' `\"multivec\"` data. For example, multiple BigWig files can be converted into a single multivec file. You can also convert sequence data (FASTA) into this format where rows will be different nucleotide bases (e.g., A, T, G, C) and quantitative values represent the frequency. Find out more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#multivec-files).",
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"
@@ -1407,19 +3740,19 @@
           "type": "array"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "row": {
-          "description": "Assign a field name of samples.",
+          "description": "Assign a field name of samples. __Default__: `\"category\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -1431,16 +3764,13 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },
       "required": [
         "type",
-        "url",
-        "column",
-        "row",
-        "value"
+        "url"
       ],
       "type": "object"
     },
@@ -1456,21 +3786,15 @@
           "type": "boolean"
         },
         "oneOf": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Check whether the value is an element in the provided list."
+          "description": "Check whether the value is an element in the provided list.",
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
         },
         "type": {
           "const": "filter",
@@ -1521,6 +3845,13 @@
       "additionalProperties": false,
       "description": "Superposing multiple tracks.",
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "_invalidTrack": {
           "description": "internal",
           "type": "boolean"
@@ -1532,6 +3863,9 @@
         "assembly": {
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+        },
+        "baselineY": {
+          "type": "number"
         },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -1562,6 +3896,27 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
         },
         "flipY": {
           "type": "boolean"
@@ -1610,6 +3965,13 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_assignedHeight": {
+                "type": "number"
+              },
+              "_assignedWidth": {
+                "description": "Internal: Used for responsive spec",
+                "type": "number"
+              },
               "_invalidTrack": {
                 "description": "internal",
                 "type": "boolean"
@@ -1621,6 +3983,9 @@
               "assembly": {
                 "$ref": "#/definitions/Assembly",
                 "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+              },
+              "baselineY": {
+                "type": "number"
               },
               "centerRadius": {
                 "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -1651,6 +4016,27 @@
               "endAngle": {
                 "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
                 "type": "number"
+              },
+              "experimental": {
+                "additionalProperties": false,
+                "properties": {
+                  "mouseEvents": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "$ref": "#/definitions/MouseEventsDeep"
+                      }
+                    ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
               },
               "flipY": {
                 "type": "boolean"
@@ -1719,7 +4105,7 @@
                 ]
               },
               "spacing": {
-                "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                 "type": "number"
               },
               "startAngle": {
@@ -1755,7 +4141,7 @@
               },
               "style": {
                 "$ref": "#/definitions/Style",
-                "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+                "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
               },
               "text": {
                 "anyOf": [
@@ -1824,7 +4210,8 @@
                   {
                     "$ref": "#/definitions/DomainChr"
                   }
-                ]
+                ],
+                "description": "Specify the visible region of genomic x-axis"
               },
               "xOffset": {
                 "description": "Specify the x offset of views in the unit of pixels",
@@ -1869,6 +4256,20 @@
                     "$ref": "#/definitions/ChannelValue"
                   }
                 ]
+              },
+              "yDomain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DomainInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChrInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChr"
+                  }
+                ],
+                "description": "Specify the visible region of genomic y-axis"
               },
               "yOffset": {
                 "description": "Specify the y offset of views in the unit of pixels",
@@ -1924,7 +4325,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -1960,7 +4361,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
@@ -2040,7 +4441,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -2086,6 +4488,20 @@
             }
           ]
         },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
+        },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
           "type": "number"
@@ -2105,15 +4521,20 @@
         }
       },
       "required": [
-        "height",
-        "overlay",
-        "width"
+        "overlay"
       ],
       "type": "object"
     },
     "OverlaidTracks": {
       "additionalProperties": false,
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "_invalidTrack": {
           "description": "internal",
           "type": "boolean"
@@ -2129,6 +4550,9 @@
         "assembly": {
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+        },
+        "baselineY": {
+          "type": "number"
         },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -2159,6 +4583,27 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
         },
         "flipY": {
           "type": "boolean"
@@ -2235,7 +4680,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -2271,7 +4716,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
@@ -2357,7 +4802,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -2403,6 +4849,20 @@
             }
           ]
         },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
+        },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
           "type": "number"
@@ -2423,27 +4883,20 @@
       },
       "required": [
         "alignment",
-        "tracks",
-        "width",
-        "height"
+        "tracks"
       ],
       "type": "object"
-    },
-    "PREDEFINED_COLORS": {
-      "enum": [
-        "viridis",
-        "grey",
-        "spectral",
-        "warm",
-        "cividis",
-        "bupu",
-        "rdbu"
-      ],
-      "type": "string"
     },
     "PartialTrack": {
       "additionalProperties": false,
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "_invalidTrack": {
           "description": "internal",
           "type": "boolean"
@@ -2455,6 +4908,9 @@
         "assembly": {
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+        },
+        "baselineY": {
+          "type": "number"
         },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -2491,6 +4947,27 @@
         "endAngle": {
           "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
         },
         "flipY": {
           "type": "boolean"
@@ -2539,6 +5016,13 @@
           "items": {
             "additionalProperties": false,
             "properties": {
+              "_assignedHeight": {
+                "type": "number"
+              },
+              "_assignedWidth": {
+                "description": "Internal: Used for responsive spec",
+                "type": "number"
+              },
               "_invalidTrack": {
                 "description": "internal",
                 "type": "boolean"
@@ -2550,6 +5034,9 @@
               "assembly": {
                 "$ref": "#/definitions/Assembly",
                 "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+              },
+              "baselineY": {
+                "type": "number"
               },
               "centerRadius": {
                 "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -2580,6 +5067,27 @@
               "endAngle": {
                 "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
                 "type": "number"
+              },
+              "experimental": {
+                "additionalProperties": false,
+                "properties": {
+                  "mouseEvents": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "$ref": "#/definitions/MouseEventsDeep"
+                      }
+                    ]
+                  },
+                  "performanceMode": {
+                    "default": false,
+                    "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
               },
               "flipY": {
                 "type": "boolean"
@@ -2648,7 +5156,7 @@
                 ]
               },
               "spacing": {
-                "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+                "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
                 "type": "number"
               },
               "startAngle": {
@@ -2684,7 +5192,7 @@
               },
               "style": {
                 "$ref": "#/definitions/Style",
-                "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+                "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
               },
               "text": {
                 "anyOf": [
@@ -2753,7 +5261,8 @@
                   {
                     "$ref": "#/definitions/DomainChr"
                   }
-                ]
+                ],
+                "description": "Specify the visible region of genomic x-axis"
               },
               "xOffset": {
                 "description": "Specify the x offset of views in the unit of pixels",
@@ -2798,6 +5307,20 @@
                     "$ref": "#/definitions/ChannelValue"
                   }
                 ]
+              },
+              "yDomain": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DomainInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChrInterval"
+                  },
+                  {
+                    "$ref": "#/definitions/DomainChr"
+                  }
+                ],
+                "description": "Specify the visible region of genomic y-axis"
               },
               "yOffset": {
                 "description": "Specify the y offset of views in the unit of pixels",
@@ -2853,7 +5376,7 @@
           ]
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -2889,7 +5412,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
@@ -2972,7 +5495,8 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
@@ -3018,6 +5542,20 @@
             }
           ]
         },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
+        },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
           "type": "number"
@@ -3038,13 +5576,27 @@
       },
       "type": "object"
     },
+    "PredefinedColors": {
+      "enum": [
+        "viridis",
+        "grey",
+        "spectral",
+        "warm",
+        "cividis",
+        "bupu",
+        "rdbu",
+        "hot",
+        "pink"
+      ],
+      "type": "string"
+    },
     "Range": {
       "anyOf": [
         {
           "$ref": "#/definitions/ValueExtent"
         },
         {
-          "$ref": "#/definitions/PREDEFINED_COLORS"
+          "$ref": "#/definitions/PredefinedColors"
         }
       ]
     },
@@ -3078,29 +5630,187 @@
       ],
       "type": "object"
     },
-    "RootSpecWithMultipleViews": {
+    "ResponsiveSize": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "height": {
+              "type": "boolean"
+            },
+            "width": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "Row": {
       "additionalProperties": false,
       "properties": {
-        "arrangement": {
-          "description": "Specify how multiple views are arranged.",
+        "clip": {
+          "description": "Clip row when the actual y value exceeds the max value of the y scale. Used only for bar marks at the moment. __Default__: `true`",
+          "type": "boolean"
+        },
+        "domain": {
+          "$ref": "#/definitions/ValueExtent",
+          "description": "Values of the data"
+        },
+        "field": {
+          "description": "Name of the data field",
+          "type": "string"
+        },
+        "grid": {
+          "description": "Whether to display grid. __Default__: `false`",
+          "type": "boolean"
+        },
+        "legend": {
+          "description": "Whether to display legend. __Default__: `false`",
+          "type": "boolean"
+        },
+        "padding": {
+          "description": "Determines the size of inner white spaces on the top and bottom of individiual rows. __Default__: `0`",
+          "type": "number"
+        },
+        "range": {
+          "$ref": "#/definitions/ValueExtent",
+          "description": "Determine the start and end position of rendering area of this track along vertical axis. __Default__: `[0, height]`"
+        },
+        "type": {
+          "const": "nominal",
+          "description": "Specify the data type",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SelectivityCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "measure": {
           "enum": [
-            "parallel",
-            "serial",
-            "horizontal",
-            "vertical"
+            "width",
+            "height",
+            "aspectRatio"
           ],
+          "type": "string"
+        },
+        "operation": {
+          "$ref": "#/definitions/LogicalOperation"
+        },
+        "target": {
+          "description": "Does the condition applied to the visualization itself or its container? __Default__: `'self'`",
+          "enum": [
+            "self",
+            "container"
+          ],
+          "type": "string"
+        },
+        "threshold": {
+          "description": "Threshold in the unit of pixels.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "operation",
+        "measure",
+        "threshold"
+      ],
+      "type": "object"
+    },
+    "SingleTrack": {
+      "additionalProperties": false,
+      "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
+        "_invalidTrack": {
+          "description": "internal",
+          "type": "boolean"
+        },
+        "_renderingId": {
+          "description": "internal",
           "type": "string"
         },
         "assembly": {
           "$ref": "#/definitions/Assembly",
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
+        "baselineY": {
+          "type": "number"
+        },
         "centerRadius": {
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
         },
-        "description": {
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Color"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "data": {
+          "$ref": "#/definitions/DataDeep"
+        },
+        "dataTransform": {
+          "items": {
+            "$ref": "#/definitions/DataTransform"
+          },
+          "type": "array"
+        },
+        "displacement": {
+          "$ref": "#/definitions/Displacement"
+        },
+        "endAngle": {
+          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+          "type": "number"
+        },
+        "experimental": {
+          "additionalProperties": false,
+          "properties": {
+            "mouseEvents": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "#/definitions/MouseEventsDeep"
+                }
+              ]
+            },
+            "performanceMode": {
+              "default": false,
+              "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "flipY": {
+          "type": "boolean"
+        },
+        "height": {
+          "description": "Specify the track height in pixels.",
+          "type": "number"
+        },
+        "id": {
           "type": "string"
+        },
+        "innerRadius": {
+          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+          "type": "number"
         },
         "layout": {
           "$ref": "#/definitions/Layout",
@@ -3110,41 +5820,159 @@
           "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
           "type": "string"
         },
+        "mark": {
+          "$ref": "#/definitions/Mark"
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Opacity"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
         "orientation": {
           "$ref": "#/definitions/Orientation",
           "description": "Specify the orientation."
         },
+        "outerRadius": {
+          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+          "type": "number"
+        },
+        "overlayOnPreviousTrack": {
+          "type": "boolean"
+        },
+        "overrideTemplate": {
+          "type": "boolean"
+        },
+        "prerelease": {
+          "additionalProperties": false,
+          "description": "internal",
+          "type": "object"
+        },
+        "row": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Row"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Size"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+          "type": "number"
+        },
+        "startAngle": {
+          "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
           "type": "number"
         },
         "static": {
           "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
           "type": "boolean"
         },
+        "stretch": {
+          "type": "boolean"
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Stroke"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "strokeWidth": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StrokeWidth"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
         },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
         "title": {
+          "description": "If defined, will show the textual label on the left-top corner of a track.",
           "type": "string"
         },
-        "views": {
-          "description": "An array of view specifications",
+        "tooltip": {
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/SingleView"
-              },
-              {
-                "$ref": "#/definitions/MultipleViews"
-              }
-            ]
+            "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
+        },
+        "visibility": {
+          "items": {
+            "$ref": "#/definitions/VisibilityCondition"
+          },
+          "type": "array"
+        },
+        "width": {
+          "description": "Specify the track width in pixels.",
+          "type": "number"
+        },
+        "x": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/X"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "x1": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/X"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "x1e": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/X"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
         },
         "xAxis": {
           "$ref": "#/definitions/AxisPosition",
@@ -3161,30 +5989,103 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
         },
+        "xe": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/X"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "y": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Y"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "y1": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Y"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "y1e": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Y"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
+        },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
           "type": "number"
+        },
+        "ye": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Y"
+            },
+            {
+              "$ref": "#/definitions/ChannelValue"
+            }
+          ]
         },
         "zoomLimits": {
           "$ref": "#/definitions/ZoomLimits"
         }
       },
       "required": [
-        "views"
+        "data",
+        "mark"
       ],
       "type": "object"
     },
-    "RootSpecWithSingleView": {
+    "SingleView": {
       "anyOf": [
         {
           "additionalProperties": false,
           "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
             "_invalidTrack": {
               "description": "internal",
               "type": "boolean"
@@ -3200,6 +6101,9 @@
             "assembly": {
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "baselineY": {
+              "type": "number"
             },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -3224,15 +6128,33 @@
               },
               "type": "array"
             },
-            "description": {
-              "type": "string"
-            },
             "displacement": {
               "$ref": "#/definitions/Displacement"
             },
             "endAngle": {
               "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
               "type": "number"
+            },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
             },
             "flipY": {
               "type": "boolean"
@@ -3288,6 +6210,403 @@
               "description": "internal",
               "type": "object"
             },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
             "row": {
               "anyOf": [
                 {
@@ -3309,7 +6628,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -3345,7 +6664,7 @@
             },
             "style": {
               "$ref": "#/definitions/Style",
-              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
             },
             "subtitle": {
               "type": "string"
@@ -3431,7 +6750,8 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
@@ -3477,6 +6797,20 @@
                 }
               ]
             },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
               "type": "number"
@@ -3497,15 +6831,20 @@
           },
           "required": [
             "alignment",
-            "height",
-            "tracks",
-            "width"
+            "tracks"
           ],
           "type": "object"
         },
         {
           "additionalProperties": false,
           "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
             "_invalidTrack": {
               "description": "internal",
               "type": "boolean"
@@ -3521,6 +6860,9 @@
             "assembly": {
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            "baselineY": {
+              "type": "number"
             },
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
@@ -3545,15 +6887,33 @@
               },
               "type": "array"
             },
-            "description": {
-              "type": "string"
-            },
             "displacement": {
               "$ref": "#/definitions/Displacement"
             },
             "endAngle": {
               "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
               "type": "number"
+            },
+            "experimental": {
+              "additionalProperties": false,
+              "properties": {
+                "mouseEvents": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/MouseEventsDeep"
+                    }
+                  ]
+                },
+                "performanceMode": {
+                  "default": false,
+                  "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
             },
             "flipY": {
               "type": "boolean"
@@ -3609,6 +6969,403 @@
               "description": "internal",
               "type": "object"
             },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
             "row": {
               "anyOf": [
                 {
@@ -3630,7 +7387,7 @@
               ]
             },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "startAngle": {
@@ -3666,7 +7423,7 @@
             },
             "style": {
               "$ref": "#/definitions/Style",
-              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
             },
             "subtitle": {
               "type": "string"
@@ -3759,7 +7516,8 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
@@ -3805,6 +7563,20 @@
                 }
               ]
             },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
+            },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
               "type": "number"
@@ -3831,6 +7603,13 @@
         {
           "additionalProperties": false,
           "properties": {
+            "_assignedHeight": {
+              "type": "number"
+            },
+            "_assignedWidth": {
+              "description": "Internal: Used for responsive spec",
+              "type": "number"
+            },
             "assembly": {
               "$ref": "#/definitions/Assembly",
               "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
@@ -3838,9 +7617,6 @@
             "centerRadius": {
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
-            },
-            "description": {
-              "type": "string"
             },
             "layout": {
               "$ref": "#/definitions/Layout",
@@ -3854,8 +7630,405 @@
               "$ref": "#/definitions/Orientation",
               "description": "Specify the orientation."
             },
+            "responsiveSpec": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "selectivity": {
+                    "items": {
+                      "$ref": "#/definitions/SelectivityCondition"
+                    },
+                    "type": "array"
+                  },
+                  "spec": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "_assignedHeight": {
+                        "type": "number"
+                      },
+                      "_assignedWidth": {
+                        "description": "Internal: Used for responsive spec",
+                        "type": "number"
+                      },
+                      "_invalidTrack": {
+                        "description": "internal",
+                        "type": "boolean"
+                      },
+                      "_renderingId": {
+                        "description": "internal",
+                        "type": "string"
+                      },
+                      "alignment": {
+                        "enum": [
+                          "overlay",
+                          "stack"
+                        ],
+                        "type": "string"
+                      },
+                      "assembly": {
+                        "$ref": "#/definitions/Assembly",
+                        "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+                      },
+                      "baselineY": {
+                        "type": "number"
+                      },
+                      "centerRadius": {
+                        "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
+                        "type": "number"
+                      },
+                      "color": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Color"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "data": {
+                        "$ref": "#/definitions/DataDeep"
+                      },
+                      "dataTransform": {
+                        "items": {
+                          "$ref": "#/definitions/DataTransform"
+                        },
+                        "type": "array"
+                      },
+                      "displacement": {
+                        "$ref": "#/definitions/Displacement"
+                      },
+                      "endAngle": {
+                        "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "experimental": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "mouseEvents": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/MouseEventsDeep"
+                              }
+                            ]
+                          },
+                          "performanceMode": {
+                            "default": false,
+                            "description": "Render visual marks with less smooth curves to increase rendering performance. Only supported for `elliptical` `linkStyle` `withinLink` currently.",
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "flipY": {
+                        "type": "boolean"
+                      },
+                      "height": {
+                        "description": "Specify the track height in pixels.",
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "innerRadius": {
+                        "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "layout": {
+                        "$ref": "#/definitions/Layout",
+                        "description": "Specify the layout type of all tracks."
+                      },
+                      "linkingId": {
+                        "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
+                        "type": "string"
+                      },
+                      "mark": {
+                        "$ref": "#/definitions/Mark"
+                      },
+                      "opacity": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Opacity"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "orientation": {
+                        "$ref": "#/definitions/Orientation",
+                        "description": "Specify the orientation."
+                      },
+                      "outerRadius": {
+                        "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
+                        "type": "number"
+                      },
+                      "overlayOnPreviousTrack": {
+                        "type": "boolean"
+                      },
+                      "overrideTemplate": {
+                        "type": "boolean"
+                      },
+                      "prerelease": {
+                        "additionalProperties": false,
+                        "description": "internal",
+                        "type": "object"
+                      },
+                      "row": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Row"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "size": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Size"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "spacing": {
+                        "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
+                        "type": "number"
+                      },
+                      "startAngle": {
+                        "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
+                        "type": "number"
+                      },
+                      "static": {
+                        "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+                        "type": "boolean"
+                      },
+                      "stretch": {
+                        "type": "boolean"
+                      },
+                      "stroke": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Stroke"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "strokeWidth": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/StrokeWidth"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "style": {
+                        "$ref": "#/definitions/Style",
+                        "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Text"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "title": {
+                        "description": "If defined, will show the textual label on the left-top corner of a track.",
+                        "type": "string"
+                      },
+                      "tooltip": {
+                        "items": {
+                          "$ref": "#/definitions/Tooltip"
+                        },
+                        "type": "array"
+                      },
+                      "tracks": {
+                        "anyOf": [
+                          {
+                            "items": {
+                              "$ref": "#/definitions/PartialTrack"
+                            },
+                            "type": "array"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "$ref": "#/definitions/PartialTrack"
+                                },
+                                {
+                                  "$ref": "#/definitions/OverlaidTracks"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ]
+                      },
+                      "visibility": {
+                        "items": {
+                          "$ref": "#/definitions/VisibilityCondition"
+                        },
+                        "type": "array"
+                      },
+                      "width": {
+                        "description": "Specify the track width in pixels.",
+                        "type": "number"
+                      },
+                      "x": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "x1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "xAxis": {
+                        "$ref": "#/definitions/AxisPosition",
+                        "description": "not supported"
+                      },
+                      "xDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic x-axis"
+                      },
+                      "xOffset": {
+                        "description": "Specify the x offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "xe": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/X"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "y1e": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "yDomain": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/DomainInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChrInterval"
+                          },
+                          {
+                            "$ref": "#/definitions/DomainChr"
+                          }
+                        ],
+                        "description": "Specify the visible region of genomic y-axis"
+                      },
+                      "yOffset": {
+                        "description": "Specify the y offset of views in the unit of pixels",
+                        "type": "number"
+                      },
+                      "ye": {
+                        "anyOf": [
+                          {
+                            "$ref": "#/definitions/Y"
+                          },
+                          {
+                            "$ref": "#/definitions/ChannelValue"
+                          }
+                        ]
+                      },
+                      "zoomLimits": {
+                        "$ref": "#/definitions/ZoomLimits"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "spec",
+                  "selectivity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
             "spacing": {
-              "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+              "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
               "type": "number"
             },
             "static": {
@@ -3864,13 +8037,7 @@
             },
             "style": {
               "$ref": "#/definitions/Style",
-              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
-            },
-            "subtitle": {
-              "type": "string"
-            },
-            "title": {
-              "type": "string"
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
             },
             "tracks": {
               "items": {
@@ -3893,11 +8060,26 @@
                 {
                   "$ref": "#/definitions/DomainChr"
                 }
-              ]
+              ],
+              "description": "Specify the visible region of genomic x-axis"
             },
             "xOffset": {
               "description": "Specify the x offset of views in the unit of pixels",
               "type": "number"
+            },
+            "yDomain": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/DomainInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChrInterval"
+                },
+                {
+                  "$ref": "#/definitions/DomainChr"
+                }
+              ],
+              "description": "Specify the visible region of genomic y-axis"
             },
             "yOffset": {
               "description": "Specify the y offset of views in the unit of pixels",
@@ -3911,362 +8093,6 @@
             "tracks"
           ],
           "type": "object"
-        }
-      ]
-    },
-    "Row": {
-      "additionalProperties": false,
-      "properties": {
-        "domain": {
-          "$ref": "#/definitions/ValueExtent",
-          "description": "Values of the data"
-        },
-        "field": {
-          "description": "Name of the data field",
-          "type": "string"
-        },
-        "grid": {
-          "description": "Whether to display grid. __Default__: `false`",
-          "type": "boolean"
-        },
-        "legend": {
-          "description": "Whether to display legend. __Default__: `false`",
-          "type": "boolean"
-        },
-        "padding": {
-          "description": "Determines the size of inner white spaces on the top and bottom of individiual rows. __Default__: `0`",
-          "type": "number"
-        },
-        "range": {
-          "$ref": "#/definitions/ValueExtent",
-          "description": "Determine the start and end position of rendering area of this track along vertical axis. __Default__: `[0, height]`"
-        },
-        "type": {
-          "const": "nominal",
-          "description": "Specify the data type",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "SingleTrack": {
-      "additionalProperties": false,
-      "properties": {
-        "_invalidTrack": {
-          "description": "internal",
-          "type": "boolean"
-        },
-        "_renderingId": {
-          "description": "internal",
-          "type": "string"
-        },
-        "assembly": {
-          "$ref": "#/definitions/Assembly",
-          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-        },
-        "centerRadius": {
-          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
-          "type": "number"
-        },
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Color"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "data": {
-          "$ref": "#/definitions/DataDeep"
-        },
-        "dataTransform": {
-          "items": {
-            "$ref": "#/definitions/DataTransform"
-          },
-          "type": "array"
-        },
-        "displacement": {
-          "$ref": "#/definitions/Displacement"
-        },
-        "endAngle": {
-          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "flipY": {
-          "type": "boolean"
-        },
-        "height": {
-          "description": "Specify the track height in pixels.",
-          "type": "number"
-        },
-        "id": {
-          "type": "string"
-        },
-        "innerRadius": {
-          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout",
-          "description": "Specify the layout type of all tracks."
-        },
-        "linkingId": {
-          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
-          "type": "string"
-        },
-        "mark": {
-          "$ref": "#/definitions/Mark"
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Opacity"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "orientation": {
-          "$ref": "#/definitions/Orientation",
-          "description": "Specify the orientation."
-        },
-        "outerRadius": {
-          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
-          "type": "number"
-        },
-        "overlayOnPreviousTrack": {
-          "type": "boolean"
-        },
-        "overrideTemplate": {
-          "type": "boolean"
-        },
-        "prerelease": {
-          "additionalProperties": false,
-          "description": "internal",
-          "type": "object"
-        },
-        "row": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Row"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Size"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
-          "type": "number"
-        },
-        "startAngle": {
-          "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "static": {
-          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
-          "type": "boolean"
-        },
-        "stretch": {
-          "type": "boolean"
-        },
-        "stroke": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Stroke"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "strokeWidth": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StrokeWidth"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "style": {
-          "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
-        },
-        "subtitle": {
-          "type": "string"
-        },
-        "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Text"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "title": {
-          "description": "If defined, will show the textual label on the left-top corner of a track.",
-          "type": "string"
-        },
-        "tooltip": {
-          "items": {
-            "$ref": "#/definitions/Tooltip"
-          },
-          "type": "array"
-        },
-        "visibility": {
-          "items": {
-            "$ref": "#/definitions/VisibilityCondition"
-          },
-          "type": "array"
-        },
-        "width": {
-          "description": "Specify the track width in pixels.",
-          "type": "number"
-        },
-        "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "x1": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "x1e": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "xAxis": {
-          "$ref": "#/definitions/AxisPosition",
-          "description": "not supported"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xOffset": {
-          "description": "Specify the x offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "xe": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y1": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y1e": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "yOffset": {
-          "description": "Specify the y offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "ye": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "zoomLimits": {
-          "$ref": "#/definitions/ZoomLimits"
-        }
-      },
-      "required": [
-        "data",
-        "height",
-        "mark",
-        "width"
-      ],
-      "type": "object"
-    },
-    "SingleView": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/OverlaidTracks"
-        },
-        {
-          "$ref": "#/definitions/StackedTracks"
-        },
-        {
-          "$ref": "#/definitions/FlatTracks"
         }
       ]
     },
@@ -4317,7 +8143,7 @@
         },
         "operation": {
           "$ref": "#/definitions/LogicalOperation",
-          "description": "A string that pecifies the logical operation to conduct between `threshold` and the `measure` of `target`. Support\n\n- greater than : \"greater-than\", \"gt\", \"GT\"\n\n- less than : \"less-than\", \"lt\", \"LT\"\n\n- greater than or equal to : \"greater-than-or-equal-to\", \"gtet\", \"GTET\"\n\n- less than or equal to : \"less-than-or-equal-to\", \"ltet\", \"LTET\""
+          "description": "A string that specifies the logical operation to conduct between `threshold` and the `measure` of `target`. Support\n\n- greater than : \"greater-than\", \"gt\", \"GT\"\n\n- less than : \"less-than\", \"lt\", \"LT\"\n\n- greater than or equal to : \"greater-than-or-equal-to\", \"gtet\", \"GTET\"\n\n- less than or equal to : \"less-than-or-equal-to\", \"ltet\", \"LTET\""
         },
         "target": {
           "description": "Target specifies the object that you want to compare with the threshold.",
@@ -4349,328 +8175,6 @@
         "operation",
         "target",
         "threshold"
-      ],
-      "type": "object"
-    },
-    "StackedTracks": {
-      "additionalProperties": false,
-      "properties": {
-        "_invalidTrack": {
-          "description": "internal",
-          "type": "boolean"
-        },
-        "_renderingId": {
-          "description": "internal",
-          "type": "string"
-        },
-        "alignment": {
-          "const": "stack",
-          "type": "string"
-        },
-        "assembly": {
-          "$ref": "#/definitions/Assembly",
-          "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
-        },
-        "centerRadius": {
-          "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
-          "type": "number"
-        },
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Color"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "data": {
-          "$ref": "#/definitions/DataDeep"
-        },
-        "dataTransform": {
-          "items": {
-            "$ref": "#/definitions/DataTransform"
-          },
-          "type": "array"
-        },
-        "displacement": {
-          "$ref": "#/definitions/Displacement"
-        },
-        "endAngle": {
-          "description": "Specify the end angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "flipY": {
-          "type": "boolean"
-        },
-        "height": {
-          "description": "Specify the track height in pixels.",
-          "type": "number"
-        },
-        "id": {
-          "type": "string"
-        },
-        "innerRadius": {
-          "description": "Specify the inner radius of tracks when (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "layout": {
-          "$ref": "#/definitions/Layout",
-          "description": "Specify the layout type of all tracks."
-        },
-        "linkingId": {
-          "description": "Specify an ID for [linking multiple views](http://gosling-lang.org/docs/user-interaction#linking-views)",
-          "type": "string"
-        },
-        "mark": {
-          "$ref": "#/definitions/Mark"
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Opacity"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "orientation": {
-          "$ref": "#/definitions/Orientation",
-          "description": "Specify the orientation."
-        },
-        "outerRadius": {
-          "description": "Specify the outer radius of tracks when `{\"layout\": \"circular\"}`.",
-          "type": "number"
-        },
-        "overlayOnPreviousTrack": {
-          "type": "boolean"
-        },
-        "overrideTemplate": {
-          "type": "boolean"
-        },
-        "prerelease": {
-          "additionalProperties": false,
-          "description": "internal",
-          "type": "object"
-        },
-        "row": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Row"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Size"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
-          "type": "number"
-        },
-        "startAngle": {
-          "description": "Specify the start angle (in the range of [0, 360]) of circular tracks (`{\"layout\": \"circular\"}`).",
-          "type": "number"
-        },
-        "static": {
-          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
-          "type": "boolean"
-        },
-        "stretch": {
-          "type": "boolean"
-        },
-        "stroke": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Stroke"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "strokeWidth": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StrokeWidth"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "style": {
-          "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
-        },
-        "subtitle": {
-          "type": "string"
-        },
-        "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Text"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "title": {
-          "description": "If defined, will show the textual label on the left-top corner of a track.",
-          "type": "string"
-        },
-        "tooltip": {
-          "items": {
-            "$ref": "#/definitions/Tooltip"
-          },
-          "type": "array"
-        },
-        "tracks": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/PartialTrack"
-              },
-              {
-                "$ref": "#/definitions/OverlaidTracks"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "visibility": {
-          "items": {
-            "$ref": "#/definitions/VisibilityCondition"
-          },
-          "type": "array"
-        },
-        "width": {
-          "description": "Specify the track width in pixels.",
-          "type": "number"
-        },
-        "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "x1": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "x1e": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "xAxis": {
-          "$ref": "#/definitions/AxisPosition",
-          "description": "not supported"
-        },
-        "xDomain": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DomainInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChrInterval"
-            },
-            {
-              "$ref": "#/definitions/DomainChr"
-            }
-          ]
-        },
-        "xOffset": {
-          "description": "Specify the x offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "xe": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/X"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y1": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "y1e": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "yOffset": {
-          "description": "Specify the y offset of views in the unit of pixels",
-          "type": "number"
-        },
-        "ye": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Y"
-            },
-            {
-              "$ref": "#/definitions/ChannelValue"
-            }
-          ]
-        },
-        "zoomLimits": {
-          "$ref": "#/definitions/ZoomLimits"
-        }
-      },
-      "required": [
-        "tracks"
       ],
       "type": "object"
     },
@@ -4754,9 +8258,26 @@
           "description": "Name of the data field",
           "type": "string"
         },
+        "legend": {
+          "description": "Whether to display legend. __Default__: `false`",
+          "type": "boolean"
+        },
         "range": {
           "$ref": "#/definitions/Range",
           "description": "Ranges of visual channel values"
+        },
+        "scaleOffset": {
+          "description": "Whether to use offset of the domain proportionally. This is bound to brushes on the color legend. __Default__: `[0, 1]`",
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "title": {
+          "description": "Title of the legend. __Default__: `undefined`",
+          "type": "string"
         },
         "type": {
           "description": "Specify the data type",
@@ -4812,13 +8333,31 @@
         "backgroundOpacity": {
           "type": "number"
         },
-        "bazierLink": {
-          "description": "Specify whether to use bazier curves for the `link` marks.",
-          "type": "boolean"
-        },
-        "circularLink": {
-          "description": "Deprecated: draw arc instead of bazier curve?",
-          "type": "boolean"
+        "brush": {
+          "additionalProperties": false,
+          "description": "Customize the style of the brush mark in the `rangeSelect` mouse event.",
+          "properties": {
+            "color": {
+              "description": "color of the marks when mouse events are triggered",
+              "type": "string"
+            },
+            "opacity": {
+              "description": "opacity of the marks when mouse events are triggered",
+              "type": "number"
+            },
+            "stroke": {
+              "description": "stroke color of the marks when mouse events are triggered",
+              "type": "string"
+            },
+            "strokeOpacity": {
+              "type": "number"
+            },
+            "strokeWidth": {
+              "description": "stroke width of the marks when mouse events are triggered",
+              "type": "number"
+            }
+          },
+          "type": "object"
         },
         "curve": {
           "description": "Specify the curve of `rule` marks.",
@@ -4832,14 +8371,9 @@
         },
         "dashed": {
           "description": "Specify the pattern of dashes and gaps for `rule` marks.",
-          "items": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "number"
-            }
-          ],
+          "items": {
+            "type": "number"
+          },
           "maxItems": 2,
           "minItems": 2,
           "type": "array"
@@ -4894,11 +8428,41 @@
           ],
           "type": "string"
         },
+        "linkMinHeight": {
+          "description": "The minimum height of `withinLink` and `betweenLink` marks. Unit is a percentagle. __Default__: `0.5`",
+          "type": "number"
+        },
+        "linkStyle": {
+          "description": "The style of `withinLink` and `betweenLink` marks. __Default__: `'circular'` `'elliptical'` will be used as a default option.",
+          "enum": [
+            "elliptical",
+            "circular",
+            "straight"
+          ],
+          "type": "string"
+        },
+        "matrixExtent": {
+          "description": "Determine to show only one side of the diagonal in a HiGlass matrix. __Default__: `\"full\"`",
+          "enum": [
+            "full",
+            "upper-right",
+            "lower-left"
+          ],
+          "type": "string"
+        },
+        "mouseOver": {
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects of `mouseOver` events on marks."
+        },
         "outline": {
           "type": "string"
         },
         "outlineWidth": {
           "type": "number"
+        },
+        "select": {
+          "$ref": "#/definitions/EventStyle",
+          "description": "Customize visual effects of `rangeSelect` events on marks ."
         },
         "textAnchor": {
           "description": "Specify the alignment of `text` marks to a given point.",
@@ -4928,14 +8492,86 @@
         "textStrokeWidth": {
           "description": "Specify the stroke width of `text` marks. Can also be specified using the `strokeWidth` channel option of `text` marks.",
           "type": "number"
+        },
+        "withinLinkVerticalLines": {
+          "description": "Whether to show vertical lines that connect to the baseline (axis) when `y` and `ye` are both used. __Default__: `false`",
+          "type": "boolean"
         }
       },
+      "type": "object"
+    },
+    "SvTypeTransform": {
+      "additionalProperties": false,
+      "properties": {
+        "firstBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types. SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
+        "newField": {
+          "type": "string"
+        },
+        "secondBp": {
+          "additionalProperties": false,
+          "description": "Based on the BEDPE, infer SV types. SV types are specified as one of the following strings: DUP, TRA, DEL, t2tINV, h2hINV.",
+          "properties": {
+            "chrField": {
+              "type": "string"
+            },
+            "posField": {
+              "type": "string"
+            },
+            "strandField": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "chrField",
+            "posField",
+            "strandField"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "const": "svType",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "firstBp",
+        "secondBp",
+        "newField"
+      ],
       "type": "object"
     },
     "TemplateTrack": {
       "additionalProperties": false,
       "description": "Template specification that will be internally converted into `SingleTrack` for rendering.",
       "properties": {
+        "_assignedHeight": {
+          "type": "number"
+        },
+        "_assignedWidth": {
+          "description": "Internal: Used for responsive spec",
+          "type": "number"
+        },
         "_invalidTrack": {
           "description": "internal",
           "type": "boolean"
@@ -5001,7 +8637,7 @@
           "type": "object"
         },
         "spacing": {
-          "description": "- If `{\"layout\": \"linear\"}`, specify the space between tracks in pixels;\n\n- If `{\"layout\": \"circular\"}`, specify the space between tracks in percentage ranging from 0 to 100.",
+          "description": "The size of the gap (1) between tracks, (2) between views, and (3) of the origin of circular tracks. The effect of this property depends on where on the spec you specify the `spacing`.\n\nIn a linear layout, this value is used in pixels, while in a circular layout, this value is used relative to the height of the tracks or views.",
           "type": "number"
         },
         "startAngle": {
@@ -5014,7 +8650,7 @@
         },
         "style": {
           "$ref": "#/definitions/Style",
-          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overriden by the style of children elements (e.g., view, track)."
+          "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
           "type": "string"
@@ -5045,11 +8681,26 @@
             {
               "$ref": "#/definitions/DomainChr"
             }
-          ]
+          ],
+          "description": "Specify the visible region of genomic x-axis"
         },
         "xOffset": {
           "description": "Specify the x offset of views in the unit of pixels",
           "type": "number"
+        },
+        "yDomain": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DomainInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChrInterval"
+            },
+            {
+              "$ref": "#/definitions/DomainChr"
+            }
+          ],
+          "description": "Specify the visible region of genomic y-axis"
         },
         "yOffset": {
           "description": "Specify the y offset of views in the unit of pixels",
@@ -5060,10 +8711,8 @@
         }
       },
       "required": [
-        "data",
-        "height",
         "template",
-        "width"
+        "data"
       ],
       "type": "object"
     },
@@ -5103,16 +8752,20 @@
       "additionalProperties": false,
       "properties": {
         "alt": {
+          "description": "Name of the data field for showing in the tooltip. Will use the field name if not specified.",
           "type": "string"
         },
         "field": {
+          "description": "Specifiy a data field whose value will show in the tooltip.",
           "type": "string"
         },
         "format": {
+          "description": "format of the data value.",
           "type": "string"
         },
         "type": {
-          "$ref": "#/definitions/FieldType"
+          "$ref": "#/definitions/FieldType",
+          "description": "Type of the data field."
         }
       },
       "required": [
@@ -5153,24 +8806,56 @@
         }
       ]
     },
+    "VcfData": {
+      "additionalProperties": false,
+      "description": "The Variant Call Format (VCF).",
+      "properties": {
+        "indexUrl": {
+          "description": "URL link to the tabix index file",
+          "type": "string"
+        },
+        "sampleLength": {
+          "description": "The maximum number of rows to be loaded from the URL. __Default:__ `1000`",
+          "type": "number"
+        },
+        "type": {
+          "const": "vcf",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL link to the VCF file",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url",
+        "indexUrl"
+      ],
+      "type": "object"
+    },
     "VectorData": {
       "additionalProperties": false,
       "description": "One-dimensional quantitative values along genomic position (e.g., bigwig) can be converted into HiGlass' `\"vector\"` format data. Find out more about this format at [HiGlass Docs](https://docs.higlass.io/data_preparation.html#bigwig-files).",
       "properties": {
+        "aggregation": {
+          "$ref": "#/definitions/BinAggregate",
+          "description": "Determine aggregation function to apply within bins. __Default__: `\"mean\"`"
+        },
         "binSize": {
           "description": "Binning the genomic interval in tiles (unit size: 256).",
           "type": "number"
         },
         "column": {
-          "description": "Assign a field name of the middle position of genomic intervals.",
+          "description": "Assign a field name of the middle position of genomic intervals. __Default__: `\"position\"`",
           "type": "string"
         },
         "end": {
-          "description": "Assign a field name of the end position of genomic intervals.",
+          "description": "Assign a field name of the end position of genomic intervals. __Default__: `\"end\"`",
           "type": "string"
         },
         "start": {
-          "description": "Assign a field name of the start position of genomic intervals.",
+          "description": "Assign a field name of the start position of genomic intervals. __Default__: `\"start\"`",
           "type": "string"
         },
         "type": {
@@ -5182,15 +8867,13 @@
           "type": "string"
         },
         "value": {
-          "description": "Assign a field name of quantitative values.",
+          "description": "Assign a field name of quantitative values. __Default__: `\"value\"`",
           "type": "string"
         }
       },
       "required": [
         "type",
-        "url",
-        "column",
-        "value"
+        "url"
       ],
       "type": "object"
     },
@@ -5266,7 +8949,14 @@
           ]
         },
         "domain": {
-          "$ref": "#/definitions/ValueExtent",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ValueExtent"
+            },
+            {
+              "$ref": "#/definitions/GenomicDomain"
+            }
+          ],
           "description": "Values of the data"
         },
         "field": {
@@ -5323,7 +9013,7 @@
         },
         "operation": {
           "$ref": "#/definitions/LogicalOperation",
-          "description": "A string that pecifies the logical operation to conduct between `threshold` and the `measure` of `target`. Support\n\n- greater than : \"greater-than\", \"gt\", \"GT\"\n\n- less than : \"less-than\", \"lt\", \"LT\"\n\n- greater than or equal to : \"greater-than-or-equal-to\", \"gtet\", \"GTET\"\n\n- less than or equal to : \"less-than-or-equal-to\", \"ltet\", \"LTET\""
+          "description": "A string that specifies the logical operation to conduct between `threshold` and the `measure` of `target`. Support\n\n- greater than : \"greater-than\", \"gt\", \"GT\"\n\n- less than : \"less-than\", \"lt\", \"LT\"\n\n- greater than or equal to : \"greater-than-or-equal-to\", \"gtet\", \"GTET\"\n\n- less than or equal to : \"less-than-or-equal-to\", \"ltet\", \"LTET\""
         },
         "target": {
           "description": "Target specifies the object that you want to compare with the threshold.",
@@ -5351,20 +9041,12 @@
       "type": "object"
     },
     "ZoomLimits": {
-      "items": [
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        {
-          "type": [
-            "number",
-            "null"
-          ]
-        }
-      ],
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      },
       "maxItems": 2,
       "minItems": 2,
       "type": "array"

--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -50,7 +50,7 @@ Any small enough tabular data files, such as tsv, csv, BED, BEDPE, and GFF, can 
 
 ```
 
-<TableWrapper objName='CSVData' GoslingSchema={GoslingSchema} />
+<TableWrapper objName='CsvData' GoslingSchema={GoslingSchema} />
 
 
 ### JSON (No HiGlass Server)
@@ -89,7 +89,7 @@ This format allows users to include data directly in the Gosling's JSON specific
 }
 ```
 
-<TableWrapper GoslingSchema={GoslingSchema} objName='JSONData'/>
+<TableWrapper GoslingSchema={GoslingSchema} objName='JsonData'/>
 
 
 ### BigWig (No HiGlass Server)
@@ -108,11 +108,11 @@ This format allows users to include data directly in the Gosling's JSON specific
 }
 ```
 
-<TableWrapper GoslingSchema={GoslingSchema} objName='BIGWIGData' />
+<TableWrapper GoslingSchema={GoslingSchema} objName='BigWigData' />
 
 ### BAM (No HiGlass Server)
 
-<TableWrapper GoslingSchema={GoslingSchema} objName='BAMData' includeDescription={true}/>
+<TableWrapper GoslingSchema={GoslingSchema} objName='BamData' includeDescription={true}/>
 
 ### BED (No HiGlass Server)
 This format allows for BED files that follow the [BED specification](https://raw.githubusercontent.com/samtools/hts-specs/master/BEDv1.pdf) to be used. 
@@ -207,7 +207,7 @@ Regular BED, or similar, files can be pre-aggregated for the scalable data explo
 }
 ```
 
-<TableWrapper GoslingSchema={GoslingSchema} objName='BEDDBData'/>
+<TableWrapper GoslingSchema={GoslingSchema} objName='BeddbData'/>
 
 
 
@@ -285,7 +285,7 @@ Each filter transform has the following properties:
 
 ### JSON Parse Transform
 
-<TableWrapper GoslingSchema={GoslingSchema} objName='JSONParseTransform' includeDescription={true}/>
+<TableWrapper GoslingSchema={GoslingSchema} objName='JsonParseTransform' includeDescription={true}/>
 
 Apart from these data transforms, users can also aggregate data values (min, max, bin, mean, and count). [Read more about data aggregation](#x)
 

--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -116,7 +116,9 @@ This format allows users to include data directly in the Gosling's JSON specific
 
 ### BED (No HiGlass Server)
 This format allows for BED files that follow the [BED specification](https://raw.githubusercontent.com/samtools/hts-specs/master/BEDv1.pdf) to be used. 
-There are 12 standard fields (`chrom`, `chromStart`, `chromEnd`, `name`, `score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, and `blockStarts`). The first three fields (`chrom`, `chromStart`, `chromEnd`) are required (they cannot be overridden by custom fields).
+There are 12 standard fields (`chrom`, `chromStart`, `chromEnd`, `name`, `score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, and `blockStarts`). 
+The first three fields (`chrom`, `chromStart`, `chromEnd`) are required. If custom fields are specified, they 
+will not be able to rename the first three fields.
 
 [BED file demo](https://gosling-lang.github.io/gosling.js/?example=doc_bed)
 ```javascript

--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -22,7 +22,8 @@ Users can specify the data of each visualization (i.e., `track`) through a `trac
 For the flexible data exploration, Gosling supports two different kinds of datasets:
 
 1. **Plain Datasets** (No HiGlass Server): These datasets can be directly used in Gosling without requiring any data preprocessing, 
-including [CSV](#csv-no-higlass-server), [JSON](#json-no-higlass-server), [BigWig](#bigwig-no-higlass-server), [BAM](#bam-no-higlass-server). 
+including [CSV](#csv-no-higlass-server), [JSON](#json-no-higlass-server), [BigWig](#bigwig-no-higlass-server), [BAM](#bam-no-higlass-server),
+[BED](#bed-no-higlass-server). 
 
 2. **Pre-aggregated Datasets** (HiGlass Server): These datasets are preprocessed for the scalable data exploration and require a HiGlass server to access them in Gosling,
 including [Vector](#vector-require-higlass-server), [Multivec](#multivec-require-higlass-server), and [BEDDB](#beddb-require-higlass-server).
@@ -112,6 +113,28 @@ This format allows users to include data directly in the Gosling's JSON specific
 ### BAM (No HiGlass Server)
 
 <TableWrapper GoslingSchema={GoslingSchema} objName='BAMData' includeDescription={true}/>
+
+### BED (No HiGlass Server)
+This format allows for BED files that follow the [BED specification](https://raw.githubusercontent.com/samtools/hts-specs/master/BEDv1.pdf) to be used. 
+There are 12 standard fields, but custom fields can be defined. 
+
+```javascript
+{
+  "tracks":[{
+    "data": {
+      "url": "https://s3.amazonaws.com/gosling-lang.org/data/bed/chr1_CDS_BED12.bed.gz",
+      "indexUrl": "https://s3.amazonaws.com/gosling-lang.org/data/bed/chr1_CDS_BED12.bed.gz.tbi"
+      "type": "bed",
+    },
+    "mark": "rect", 
+      "x": {"field": "chromStart", "type": "genomic"}, // example using one of the standard fields
+      "xe": {"field": "chromEnd", "type": "genomic"},
+    ... // other configurations of this track
+  }]
+}
+```
+
+<TableWrapper GoslingSchema={GoslingSchema} objName='BedData' includeDescription={true}/>
 
 ### Vector (Require HiGlass Server)
 

--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -118,6 +118,7 @@ This format allows users to include data directly in the Gosling's JSON specific
 This format allows for BED files that follow the [BED specification](https://raw.githubusercontent.com/samtools/hts-specs/master/BEDv1.pdf) to be used. 
 There are 12 standard fields (`chrom`, `chromStart`, `chromEnd`, `name`, `score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, and `blockStarts`), but custom fields can be defined. 
 
+[BED file demo](https://gosling-lang.github.io/gosling.js/?example=doc_bed)
 ```javascript
 {
   "tracks":[{

--- a/docs/data.mdx
+++ b/docs/data.mdx
@@ -116,7 +116,7 @@ This format allows users to include data directly in the Gosling's JSON specific
 
 ### BED (No HiGlass Server)
 This format allows for BED files that follow the [BED specification](https://raw.githubusercontent.com/samtools/hts-specs/master/BEDv1.pdf) to be used. 
-There are 12 standard fields, but custom fields can be defined. 
+There are 12 standard fields (`chrom`, `chromStart`, `chromEnd`, `name`, `score`, `strand`, `thickStart`, `thickEnd`, `itemRgb`, `blockCount`, `blockSizes`, and `blockStarts`), but custom fields can be defined. 
 
 ```javascript
 {


### PR DESCRIPTION
Corresponds to [PR](https://github.com/gosling-lang/gosling.js/pull/877) for gosling.js. 

Adds documentation for the new BED data fetcher. 