### PR TITLE
Use of genomicFieldsToConvert

### DIFF
--- a/versioned_docs/version-0.9.20/data.mdx
+++ b/versioned_docs/version-0.9.20/data.mdx
@@ -294,3 +294,25 @@ Apart from these data transforms, users can also aggregate data values (min, max
 
 #### Type: SECONDBP
 <TableWrapper GoslingSchema={GoslingSchema} objName='SvTypeTransform-properties-firstBp' />
+
+## Field convert
+
+### genomicFieldsToConvert
+
+To connect two points on different chromosomes when using the `link` *Mark*, the `genomicFieldsToConvert` of *Data* should be used:
+
+```javascript
+data: {
+    ...,
+    "genomicFieldsToConvert": [
+                  {
+                    "chromosomeField": "chr1",
+                    "genomicFields": ["start1", "end1"]
+                  },
+                  {
+                    "chromosomeField": "chr2",
+                    "genomicFields": ["start2", "end2"]
+                  }
+    ]
+}
+```


### PR DESCRIPTION
Currently the doc for the `link` *Mark* only works for points on the same chromosome. I find the solution to connect points on different chromosomes in the example https://gosling.js.org/#Visual%20Encoding_Visual%20Encoding, and hope this should be clarified in the doc.