### PR TITLE
DummyTrack documentation 

### DIFF
--- a/docs/assets/gosling.schema.json
+++ b/docs/assets/gosling.schema.json
@@ -957,6 +957,10 @@
           "description": "Background color of the track",
           "type": "string"
         },
+        "outline": {
+          "description": "Color of the outline of the track",
+          "type": "string"
+        },
         "textFontSize": {
           "description": "Specify the font size of the title",
           "type": "number"

--- a/docs/assets/gosling.schema.json
+++ b/docs/assets/gosling.schema.json
@@ -598,6 +598,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -877,6 +878,106 @@
       "required": [
         "interval"
       ],
+      "type": "object"
+    },
+    "DummyTrack": {
+      "additionalProperties": false,
+      "description": "A placeholder track. In contrast to other tracks, this track does not display any data. Instead it provides empty space for third party tools to display their data on top of.",
+      "properties": {
+        "_invalidTrack": {
+          "description": "internal",
+          "type": "boolean"
+        },
+        "assembly": {
+          "const": "unknown",
+          "description": "No assemblies can be associated with a dummy track",
+          "type": "string"
+        },
+        "height": {
+          "description": "Specify the track height in pixels.",
+          "type": "number"
+        },
+        "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
+          "type": "string"
+        },
+        "layout": {
+          "const": "linear",
+          "description": "Only linear layout are supported at this time",
+          "type": "string"
+        },
+        "orientation": {
+          "$ref": "#/definitions/Orientation",
+          "description": "Specify the orientation."
+        },
+        "overlayOnPreviousTrack": {
+          "type": "boolean"
+        },
+        "static": {
+          "const": true,
+          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+          "type": "boolean"
+        },
+        "style": {
+          "$ref": "#/definitions/DummyTrackStyle",
+          "description": "Defines how the track is styled"
+        },
+        "title": {
+          "description": "Text that gets shown on the DummyTrack",
+          "type": "string"
+        },
+        "type": {
+          "const": "dummy-track",
+          "description": "Used to specify the dummy track",
+          "type": "string"
+        },
+        "width": {
+          "description": "Specify the track width in pixels.",
+          "type": "number"
+        },
+        "zoomLimits": {
+          "description": "Unused property for DummyTrack",
+          "items": {
+            "type": "null"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "DummyTrackStyle": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "description": "Background color of the track",
+          "type": "string"
+        },
+        "textFontSize": {
+          "description": "Specify the font size of the title",
+          "type": "number"
+        },
+        "textFontWeight": {
+          "description": "Specify the font weight of the title.",
+          "enum": [
+            "bold",
+            "normal"
+          ],
+          "type": "string"
+        },
+        "textStroke": {
+          "description": "Specify the stroke color of title.",
+          "type": "string"
+        },
+        "textStrokeWidth": {
+          "description": "Specify the stroke width of the title.",
+          "type": "number"
+        }
+      },
       "type": "object"
     },
     "EventStyle": {
@@ -1179,6 +1280,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -1330,6 +1432,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -1945,6 +2048,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -2096,6 +2200,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -2647,6 +2752,10 @@
             "description": {
               "type": "string"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -2764,6 +2873,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -3164,6 +3274,10 @@
             "description": {
               "type": "string"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -3217,6 +3331,10 @@
                       "centerRadius": {
                         "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
                         "type": "number"
+                      },
+                      "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+                        "type": "string"
                       },
                       "layout": {
                         "$ref": "#/definitions/Layout",
@@ -3684,6 +3802,10 @@
           "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
           "type": "number"
         },
+        "id": {
+          "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+          "type": "string"
+        },
         "layout": {
           "$ref": "#/definitions/Layout",
           "description": "Specify the layout type of all tracks."
@@ -3977,6 +4099,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -4093,6 +4216,7 @@
                 "type": "boolean"
               },
               "id": {
+                "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
                 "type": "string"
               },
               "innerRadius": {
@@ -4664,6 +4788,7 @@
           "type": "number"
         },
         "id": {
+          "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
           "type": "string"
         },
         "innerRadius": {
@@ -4957,7 +5082,17 @@
           "type": "string"
         },
         "assembly": {
-          "$ref": "#/definitions/Assembly",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Assembly",
+              "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
+            },
+            {
+              "const": "unknown",
+              "description": "No assemblies can be associated with a dummy track",
+              "type": "string"
+            }
+          ],
           "description": "A string that specifies the genome builds to use. Currently support `\"hg38\"`, `\"hg19\"`, `\"hg18\"`, `\"hg17\"`, `\"hg16\"`, `\"mm10\"`, `\"mm9\"`, and `\"unknown\"`.\n\n__Note:__: with `\"unknown\"` assembly, genomic axes do not show chrN: in labels."
         },
         "baselineY": {
@@ -5028,6 +5163,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -5035,7 +5171,17 @@
           "type": "number"
         },
         "layout": {
-          "$ref": "#/definitions/Layout",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Layout",
+              "description": "Specify the layout type of all tracks."
+            },
+            {
+              "const": "linear",
+              "description": "Only linear layout are supported at this time",
+              "type": "string"
+            }
+          ],
           "description": "Specify the layout type of all tracks."
         },
         "linkingId": {
@@ -5144,6 +5290,7 @@
                 "type": "boolean"
               },
               "id": {
+                "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
                 "type": "string"
               },
               "innerRadius": {
@@ -5435,8 +5582,18 @@
           "type": "number"
         },
         "static": {
-          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            },
+            {
+              "const": true,
+              "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`.",
+              "type": "boolean"
+            }
+          ],
+          "description": "Whether to disable [Zooming and Panning](http://gosling-lang.org/docs/user-interaction#zooming-and-panning), __Default:__ `false`."
         },
         "stretch": {
           "type": "boolean"
@@ -5462,7 +5619,16 @@
           ]
         },
         "style": {
-          "$ref": "#/definitions/Style",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Style",
+              "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
+            },
+            {
+              "$ref": "#/definitions/DummyTrackStyle",
+              "description": "Defines how the track is styled"
+            }
+          ],
           "description": "Define the [style](http://gosling-lang.org/docs/visual-channel#style-related-properties) of multive views. Will be overwritten by the style of children elements (e.g., view, track)."
         },
         "subtitle": {
@@ -5490,6 +5656,11 @@
             "$ref": "#/definitions/Tooltip"
           },
           "type": "array"
+        },
+        "type": {
+          "const": "dummy-track",
+          "description": "Used to specify the dummy track",
+          "type": "string"
         },
         "visibility": {
           "items": {
@@ -5622,7 +5793,20 @@
           ]
         },
         "zoomLimits": {
-          "$ref": "#/definitions/ZoomLimits"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ZoomLimits"
+            },
+            {
+              "description": "Unused property for DummyTrack",
+              "items": {
+                "type": "null"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            }
+          ]
         }
       },
       "type": "object"
@@ -5857,6 +6041,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -6215,6 +6400,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -6362,6 +6548,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -6974,6 +7161,7 @@
               "type": "number"
             },
             "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
               "type": "string"
             },
             "innerRadius": {
@@ -7121,6 +7309,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -7669,6 +7858,10 @@
               "description": "Proportion of the radius of the center white space.\n\n__Default:__ `0.3`",
               "type": "number"
             },
+            "id": {
+              "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
+              "type": "string"
+            },
             "layout": {
               "$ref": "#/definitions/Layout",
               "description": "Specify the layout type of all tracks."
@@ -7782,6 +7975,7 @@
                         "type": "number"
                       },
                       "id": {
+                        "description": "The ID of a view that is maintained for the use of JS API functions, e.g., positions of a view",
                         "type": "string"
                       },
                       "innerRadius": {
@@ -8657,6 +8851,7 @@
           "type": "number"
         },
         "id": {
+          "description": "Assigned to `uid` in a HiGlass view config, used for API and caching.",
           "type": "string"
         },
         "innerRadius": {
@@ -8838,6 +9033,9 @@
         },
         {
           "$ref": "#/definitions/TemplateTrack"
+        },
+        {
+          "$ref": "#/definitions/DummyTrack"
         }
       ]
     },

--- a/docs/composition.mdx
+++ b/docs/composition.mdx
@@ -208,11 +208,15 @@ Try examples in the online editor:
 
 [Ideogram (text + rect + triangle)](<https://gosling-lang.github.io/gosling.js/?example=doc_overlay_rect_text>)
 
-## Placeholder track to show non-Gosling visualizations
+## Integrating non-Gosling visualizations
 
-If you want to show non-Gosling visualizations within a Gosling visualization, you can use `DummyTrack` as a 
-placeholder to create space for your visualization. Your custom visualization can then be overlaid on top of 
-the `DummyTrack`. Currently, `DummyTrack` can only be used with a linear `layout`.
+You may want to visualize a non-Gosling visualization within a Gosling visualization, such as showing a lineage tree along with multiple sequences.
+
+In Gosling, you can do this by using `DummyTrack` as a placeholder to create space for your non-Gosling visualization. Your non-Gosling visualization can then be overlaid on top of the `DummyTrack` using [JS API functions](./js-api) to get the position of the placeholder.
+
+:::caution
+`DummyTrack` can only be used with a linear `layout` at the moment.
+:::
 
 [DummyTrack demo in the Editor](https://gosling-lang.github.io/gosling.js/?example=doc_dummy_track)
 

--- a/docs/composition.mdx
+++ b/docs/composition.mdx
@@ -207,37 +207,3 @@ Try examples in the online editor:
 [Line chart (line + point)](<https://gosling-lang.github.io/gosling.js/?example=doc_overlay_line_point>)
 
 [Ideogram (text + rect + triangle)](<https://gosling-lang.github.io/gosling.js/?example=doc_overlay_rect_text>)
-
-## Integrating non-Gosling visualizations
-
-You may want to visualize a non-Gosling visualization within a Gosling visualization, such as showing a lineage tree along with multiple sequences.
-
-In Gosling, you can do this by using `DummyTrack` as a placeholder to create space for your non-Gosling visualization. Your non-Gosling visualization can then be overlaid on top of the `DummyTrack` using [JS API functions](./js-api) to get the position of the placeholder.
-
-:::caution
-`DummyTrack` can only be used with a linear `layout` at the moment.
-:::
-
-[DummyTrack demo in the Editor](https://gosling-lang.github.io/gosling.js/?example=doc_dummy_track)
-
-Here's a `DummyTrack` specification example
-```javascript
-"tracks": [
-    {
-      "type": "dummy-track",
-      "title": "Placeholder",
-      "id": "my_track",
-      "height": 200,
-      "width": 300,
-      "style": {"background": "#e6e6e6", "textFontSize": 8, "textFontWeight": "normal"}
-    }
-],
-
-```
-
-`DummyTrack` properties: 
-<TableWrapper objName='DummyTrack' GoslingSchema={GoslingSchema} />
-
-`DummyTrack` can be styled in the following way: 
-
-<TableWrapper objName='DummyTrackStyle' GoslingSchema={GoslingSchema} />

--- a/docs/composition.mdx
+++ b/docs/composition.mdx
@@ -225,7 +225,7 @@ Here's a `DummyTrack` specification example
       "id": "my_track",
       "height": 200,
       "width": 300,
-      "style": {"background": "#e6e6e6", "textFontSize": 8, "textFontWeight": "normal}
+      "style": {"background": "#e6e6e6", "textFontSize": 8, "textFontWeight": "normal"}
     }
 ],
 

--- a/docs/composition.mdx
+++ b/docs/composition.mdx
@@ -207,3 +207,33 @@ Try examples in the online editor:
 [Line chart (line + point)](<https://gosling-lang.github.io/gosling.js/?example=doc_overlay_line_point>)
 
 [Ideogram (text + rect + triangle)](<https://gosling-lang.github.io/gosling.js/?example=doc_overlay_rect_text>)
+
+## Placeholder track to show non-Gosling visualizations
+
+If you want to show non-Gosling visualizations within a Gosling visualization, you can use `DummyTrack` as a 
+placeholder to create space for your visualization. Your custom visualization can then be overlaid on top of 
+the `DummyTrack`. Currently, `DummyTrack` can only be used with a linear `layout`.
+
+[DummyTrack demo in the Editor](https://gosling-lang.github.io/gosling.js/?example=doc_dummy_track)
+
+Here's a `DummyTrack` specification example
+```javascript
+"tracks": [
+    {
+      "type": "dummy-track",
+      "title": "Placeholder",
+      "id": "my_track",
+      "height": 200,
+      "width": 300,
+      "style": {"background": "#e6e6e6", "textFontSize": 8, "textFontWeight": "normal}
+    }
+],
+
+```
+
+`DummyTrack` properties: 
+<TableWrapper objName='DummyTrack' GoslingSchema={GoslingSchema} />
+
+`DummyTrack` can be styled in the following way: 
+
+<TableWrapper objName='DummyTrackStyle' GoslingSchema={GoslingSchema} />

--- a/docs/non-gos-vis.mdx
+++ b/docs/non-gos-vis.mdx
@@ -1,0 +1,42 @@
+---
+title: Integrating non-Gosling visualizations
+---
+
+import {TableWrapper} from '@site/react-components/DocComponments/table'
+import GoslingSchema from './assets/gosling.schema.json'
+
+# Integrating non-Gosling visualizations
+
+You may want to visualize a non-Gosling visualization within a Gosling visualization, such as showing a lineage tree along with multiple sequences.
+
+In Gosling, you can do this by using `DummyTrack` as a placeholder to create space for your non-Gosling visualization. 
+Your non-Gosling visualization can then be overlaid on top of the `DummyTrack` using [JS API functions](./js-api) to 
+get the position of the placeholder.
+
+:::caution
+`DummyTrack` can only be used with a linear `layout` at the moment.
+:::
+
+[DummyTrack demo in the Editor](https://gosling-lang.github.io/gosling.js/?example=doc_dummy_track)
+
+Here's a `DummyTrack` specification example
+```javascript
+"tracks": [
+    {
+      "type": "dummy-track",
+      "title": "Placeholder",
+      "id": "my_track",
+      "height": 200,
+      "width": 300,
+      "style": {"background": "#e6e6e6", "textFontSize": 8, "textFontWeight": "normal"}
+    }
+],
+
+```
+
+`DummyTrack` properties: 
+<TableWrapper objName='DummyTrack' GoslingSchema={GoslingSchema} />
+
+`DummyTrack` has a `style` property which can take an object with the following properties:
+
+<TableWrapper objName='DummyTrackStyle' GoslingSchema={GoslingSchema} />

--- a/sidebarDocs.js
+++ b/sidebarDocs.js
@@ -25,6 +25,11 @@ module.exports = {
     },
     {
       type: 'doc',
+      label: 'Integrating non-Gosling visualizations',
+      id: 'non-gos-vis',
+    },
+    {
+      type: 'doc',
       id: 'public-datasets',
     },
     {


### PR DESCRIPTION
Documentation for `DummyTrack`. Corresponds to https://github.com/gosling-lang/gosling.js/pull/946 