### PR TITLE
feat: rename to React Component API

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ slug: /
 
 Gosling.js is a declarative grammar for interactive (epi)genomics visualization on the Web.
 
-To get started with Gosling, we recommend going through the [Create Single Track Visualization Tutorial](/tutorials). Then, you can explore examples in the [online editor](https://gosling.js.org), go through the [grammar guide](category/grammar-guide), and start building your own Gosling visualizations using the the [grammar reference](reference) and [Javascript API](js-api) documentation. 
+To get started with Gosling, we recommend going through the [Create Single Track Visualization Tutorial](/tutorials). Then, you can explore examples in the [online editor](https://gosling.js.org), go through the [grammar guide](category/grammar-guide), and start building your own Gosling visualizations using the the [grammar reference](reference) and [React Component API](react-api) documentation. 
 
 Please see [usage guide](usage) to learn about all the contexts in which Gosling can be used. 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,8 +18,8 @@ How is the Gosling grammar used in practice? A Gosling visualization is defined 
 
 <img src='/img/spec-vis.png'/>
 
-## Javascript API 
+## React Component API 
 
-**Gosling.js** takes the Gosling specification as an input and creates the visualization defined by it. You can programmatically interact with this visualization using **Javascript API functions**. 
+**Gosling.js** takes the Gosling specification as an input and creates the visualization defined by it. You can programmatically interact with this visualization using the [React component API](react-api).
 
 For example, you can use an API function to make the visualization zoom to a particular genomic position, or you can subscribe to click events in the visualization. This is useful to building your own interactive visualizations with Gosling! 

--- a/docs/react-api.md
+++ b/docs/react-api.md
@@ -1,5 +1,5 @@
 ---
-title: JavaScript API
+title: React Component API
 ---
 
 ## GoslingComponent

--- a/sidebarDocs.js
+++ b/sidebarDocs.js
@@ -37,8 +37,8 @@ module.exports = {
     },
     {
       type: 'doc',
-      label: 'JavaScript API',
-      id: 'js-api',
+      label: 'React Component API',
+      id: 'react-api',
     },
     {
       type: 'doc',


### PR DESCRIPTION
This renames Javascript API to React Component API for clarity. 